### PR TITLE
Bug Fix: Run kentaro-m/auto-assign-action@v1.1.2 - Failed

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,22 @@
+addReviewers: true
+
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+# Reviewer must have admin permission
+reviewers: 
+  - AvinashMahanthi
+#  - Reviewer 2 
+
+skipKeywords:
+  - wip
+  - draft
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# A list of assignees, overrides reviewers if set
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+# skipKeywords:
+#   - wip

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -6,7 +6,7 @@ addAssignees: author
 # Reviewer must have admin permission
 reviewers: 
   - AvinashMahanthi
-#  - Reviewer 2 
+  - AkashM398 
 
 skipKeywords:
   - wip


### PR DESCRIPTION
## Related Issues or Pull Requests

Bug Fix: Run kentaro-m/auto-assign-action@v1.1.2 

### Brief explanation of the Problem statement

Added up the auto_assign.yml file to assign roles automatically for reviewers and assignees. This file will resolve the check error in the Pull Request.

### Solution to the problem statement

By adding the auto_assign.yml file in the repository

### Checklist

- [x] I've read the contribution guidelines.
- [x] I've checked the issue list before deciding what to submit.

#### File(s) Added / Modified

>  `.github/auto_assign.yml`

<!-- Change it appropriately -->

#### How to test:
You test it after merging the pull request.
<!-- Change it appropriately in the form of points -->

#### Screenshots:
Tested on [KamalDGRT/event-aggregator-demo](https://github.com/KamalDGRT/event-aggregator-demo)
![Screenshot from 2021-04-11 20-28-30](https://user-images.githubusercontent.com/39455174/114309510-02db4b80-9b05-11eb-9077-5f764ecd9813.png)
![Screenshot from 2021-04-11 20-31-07](https://user-images.githubusercontent.com/39455174/114309515-07076900-9b05-11eb-8f24-375147068f45.png)
![Screenshot from 2021-04-11 20-31-10](https://user-images.githubusercontent.com/39455174/114309520-0b338680-9b05-11eb-8c9b-6523da1fb85c.png)

<!-- Add relavent screen shots here-->