### PR TITLE
[Feature] Greets while closing Issues/PR 

### DIFF
--- a/.github/workflows/auto_close_greeting.yml
+++ b/.github/workflows/auto_close_greeting.yml
@@ -1,0 +1,18 @@
+name: Greetings
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == false }}
+    steps:
+    - uses: Manoj-Paramsetti/Greeting-action@main
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        issue_message: 'Thank you for taking out your time to raise an issue.<br>This issue is closed by @${{github.actor}} 🤗'
+        PR_message: Thank you for taking out your time and tried to contribute to **Opportunity Tracker** repository.<br>We are sorry to say that this pull request is closed by @${{github.actor}} without merging.<br>Don't lose the hope 💪

--- a/.github/workflows/merge_greeting.yml
+++ b/.github/workflows/merge_greeting.yml
@@ -1,0 +1,18 @@
+#new labels will be created while closing some issue so create a label for 'closed', 'expired'
+name: Merge Greetings
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true }}
+    steps:
+    - uses: Manoj-Paramsetti/Greeting-action@main
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        issue_message: 'Thank you for taking out your time to raise an issue.<br>This issue is closed by @${{github.actor}}'
+        PR_message: '<h1>:partying_face: Congratulations :tada:</h1>Thank you for taking out your time and contributing to our project.<br>This pull request is merged and closed successfully by @${{github.actor}} 😉'
+#issue message will not work here so ignore the issue_message


### PR DESCRIPTION
## Related Issues or Pull Requests

#6 

### Brief explanation of the Problem statement

I added a new feature. Which can send the greetings when closing the issue/pull request
## Note: In this feature, two labels will be added:
> expired

> closed
### Give a nice color for that :smiley_cat: 
### Checklist

- [x] I've read the contribution guidelines.
- [x] I've checked the issue list before deciding what to submit.

#### File Added

- `auto_close_greetings.yml`
<!-- Change it appropriately -->


#### Screenshots:
![Screenshot from 2021-04-14 07-18-18](https://user-images.githubusercontent.com/39455174/114642578-cb7dc200-9cf1-11eb-872c-9942ea5213de.png)
![Screenshot from 2021-04-14 07-11-30](https://user-images.githubusercontent.com/39455174/114642585-cfa9df80-9cf1-11eb-9a8e-b929bcb52441.png)

