### PR TITLE
[Feature] Greets while closing an Issues/PR 

### DIFF
--- a/.github/workflows/auto_close_greeting.yml
+++ b/.github/workflows/auto_close_greeting.yml
@@ -1,0 +1,27 @@
+name: Greets Action
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Manoj-Paramsetti/greets-action@main
+        if: ${{ github.event.pull_request.merged == true }}
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pr_message: 'Thank you for taking out time to contribute to our project. This pull request is merged and closed successfully by @${{github.actor}}'
+          label_1: 'merged'
+          label_2: 'closed'
+
+      - uses: Manoj-Paramsetti/greets-action@main
+        if: ${{ github.event.pull_request.merged == false}}
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: 'Thank you for taking your time to raise an issue.<br>This issue is closed by @${{github.actor}}'
+          pr_message: 'Thank you for taking your time to contribute in Opportunity Tracker repository. This pull request is closed successfully by @${{github.actor}}'
+          label_1: 'closed'


### PR DESCRIPTION
## Related Issues or Pull Requests

#6 

### Brief explanation of the Problem statement

I added a new feature. Which can send the greetings when closing the issue or pull request
## Note: In this feature, two labels will be added:
> merged

> closed
### Give a nice color for that :smiley_cat: 
### Checklist

- [x] I've read the contribution guidelines.
- [x] I've checked the issue list before deciding what to submit.

#### File Added

- `auto_close_greeting.yml`
- `merge_greeting.yml`
<!-- Change it appropriately -->


#### Screenshots:
![Screenshot from 2021-04-16 15-30-40](https://user-images.githubusercontent.com/39455174/115013354-8cf12e80-9ece-11eb-99ae-78cdcd7d8741.png)
![Screenshot from 2021-04-16 15-29-15](https://user-images.githubusercontent.com/39455174/115013360-8ebaf200-9ece-11eb-9ebd-dd64fde801a3.png)
![Screenshot from 2021-04-16 15-26-32](https://user-images.githubusercontent.com/39455174/115013363-8f538880-9ece-11eb-9d72-83a348b2f7ee.png)
**Note: The screenshots are not having the same return message. Check issue_message and PR _message tag to see the returning message**